### PR TITLE
load_data.py Refinement Following Review Feedback

### DIFF
--- a/fluent_pose_synthesis/data/load_data.py
+++ b/fluent_pose_synthesis/data/load_data.py
@@ -98,9 +98,9 @@ class SignLanguagePoseDataset(Dataset):
         with open(sample["metadata_path"], "r", encoding="utf-8") as f:
             metadata = json.load(f)
 
-        # # Apply in-place normalization
-        # fluent_pose.normalize()
-        # disfluent_pose.normalize()
+        # Apply normalization by shoulders width first
+        fluent_pose.normalize()
+        disfluent_pose.normalize()
 
         fluent_data = np.array(fluent_pose.body.data.astype(self.dtype))
         # Use the entire disfluent sequence as condition

--- a/fluent_pose_synthesis/data/load_data.py
+++ b/fluent_pose_synthesis/data/load_data.py
@@ -76,6 +76,10 @@ class SignLanguagePoseDataset(Dataset):
         else:
             self.pose_header = None
 
+        # Repeat the dataset for testing purposes
+        self.examples = self.examples * 10
+        print(f"Dataset expanded to {len(self.examples)} samples after repeating.")
+
     def __len__(self) -> int:
         """
         Returns the number of samples in the dataset.
@@ -99,9 +103,12 @@ class SignLanguagePoseDataset(Dataset):
         with open(sample["metadata_path"], "r", encoding="utf-8") as f:
             metadata = json.load(f)
 
-        # Apply normalization by shoulders width first (spatial normalization)
-        fluent_pose.normalize()
-        disfluent_pose.normalize()
+        # Before normalization: extract raw data for statistics
+        fluent_data_raw = np.array(fluent_pose.body.data.astype(self.dtype))
+        disfluent_data_raw = np.array(disfluent_pose.body.data.astype(self.dtype))
+
+        print(f"[DEBUG][Before Norm] Fluent raw data mean: {fluent_data_raw.mean()}, std: {fluent_data_raw.std()}")
+        print(f"[DEBUG][Before Norm] Disfluent raw data mean: {disfluent_data_raw.mean()}, std: {disfluent_data_raw.std()}")
 
         # Apply full-pose normalization using global mean/std (scale normalization)
         fluent_pose = normalize_mean_std(fluent_pose)
@@ -110,6 +117,9 @@ class SignLanguagePoseDataset(Dataset):
         fluent_data = np.array(fluent_pose.body.data.astype(self.dtype))
         # Use the entire disfluent sequence as condition
         disfluent_data = np.array(disfluent_pose.body.data.astype(self.dtype))
+
+        print(f"[DEBUG][After Norm] Fluent data mean: {fluent_data.mean()}, std: {fluent_data.std()}")
+        print(f"[DEBUG][After Norm] Disfluent data mean: {disfluent_data.mean()}, std: {disfluent_data.std()}")
 
         fluent_length = len(fluent_data)
 

--- a/fluent_pose_synthesis/data/load_data.py
+++ b/fluent_pose_synthesis/data/load_data.py
@@ -110,6 +110,10 @@ class SignLanguagePoseDataset(Dataset):
         print(f"[DEBUG][Before Norm] Fluent raw data mean: {fluent_data_raw.mean()}, std: {fluent_data_raw.std()}")
         print(f"[DEBUG][Before Norm] Disfluent raw data mean: {disfluent_data_raw.mean()}, std: {disfluent_data_raw.std()}")
 
+        # Apply normalization by shoulders width first (spatial normalization)
+        fluent_pose.normalize()
+        disfluent_pose.normalize()
+
         # Apply full-pose normalization using global mean/std (scale normalization)
         fluent_pose = normalize_mean_std(fluent_pose)
         disfluent_pose = normalize_mean_std(disfluent_pose)


### PR DESCRIPTION
- Removed random windowing of fluent_clip, replacing it with a fixed-length slice from the start of the sequence (fluent_clip = data[:fluent_frames]). → to avoid the one-to-many mapping issue between identical conditions and differing targets, as highlighted by Mingyi, which may otherwise hinder stable learning.

- Replaced in-place normalization with per-sample standardization using (x - mean) / std.

- Removed input_mask from the output dictionary, as it was not used in the loss function or model forward pass.

- Added explicit padding to fluent_clip using the last valid frame when sequence length is shorter than fluent_frames. → for a consistent target length across samples, which is critical when applying MSE loss directly without masking (for now)

- Maintained the use of zero_pad_collator, limited to the disfluent_seq input.